### PR TITLE
Add image button to toolbar

### DIFF
--- a/web/static/thesis-editor.js
+++ b/web/static/thesis-editor.js
@@ -15,7 +15,7 @@ const mediumEditorOptions = {
   toolbar: {
     buttons: [
       'bold', 'italic', 'underline', 'anchor',
-      'h1', 'h2', 'h3', 'quote', 'pre',
+      'h1', 'h2', 'h3', 'quote', 'pre', 'image',
       'orderedList', 'unorderedList', 'outdent', 'indent',
       'removeFormat'
     ],


### PR DESCRIPTION
This enables simple image support. Usage is not totally intuitive: you have to enter the image URL _on its own line,_ select it, then click the image button.
