### PR TITLE
Add module doc to ThesisAuth to make dogma happy

### DIFF
--- a/priv/templates/thesis.install/thesis_auth.exs
+++ b/priv/templates/thesis.install/thesis_auth.exs
@@ -1,4 +1,8 @@
 defmodule <%= base %>.ThesisAuth do
+  @moduledoc """
+  Contains functions for handling Thesis authorization.
+  """
+
   def page_is_editable?(conn) do
     # Editable by the world
     true


### PR DESCRIPTION
Dogma expects all modules to have module docs. This adds a simple one to ThesisAuth.

@jamonholmgren 