### PR TITLE
Added global content areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ becomes...
 <h1><%= content(@conn, "Title identifier", :text, do: "My Title") %></h1>
 ```
 
+### Global Content Areas
+
+Content areas in Thesis are page-specific. However, if you want an editable
+region that can be displayed on multiple pages, use the
+`Thesis.View.global_content/4` function. Internally, the page_id will be set
+to `nil` to indicate it applies globally, rather than to a specific page.
+
+```eex
+<%= global_content(@conn, "Footer Text", :html) do %>
+  <h4>Contact Info</h4>
+  <ul>
+    <li>Call us at (800) 555-1212</li>
+    <li>Email us at hello@example.com.</li>
+  </ul>
+<% end %>
+```
+
 ### Meta Title and Description
 
 In your layout, you can output the current title and description like so:

--- a/lib/thesis/models/page_content.ex
+++ b/lib/thesis/models/page_content.ex
@@ -20,4 +20,28 @@ defmodule Thesis.PageContent do
 
     timestamps
   end
+
+  @doc """
+  Selects the right page content from a list.
+
+      iex> foo = [%Thesis.PageContent{id: 1, page_id: nil, name: "Test"},%Thesis.PageContent{id: 2, page_id: 1, name: "Test"},%Thesis.PageContent{id: 3, page_id: 2, name: "Test"},%Thesis.PageContent{id: 4, page_id: nil, name: "Test2"},%Thesis.PageContent{id: 5, page_id: 1, name: "Test2"}]
+      iex> Thesis.PageContent.find(foo, nil, "Test").id == 1
+      true
+      iex> Thesis.PageContent.find(foo, 1, "Test").id == 2
+      true
+      iex> Thesis.PageContent.find(foo, 2, "Test").id == 3
+      true
+      iex> Thesis.PageContent.find(foo, nil, "Test2").id == 4
+      true
+      iex> Thesis.PageContent.find(foo, 1, "Test2").id == 5
+      true
+      iex> Thesis.PageContent.find(foo, 1, "Test7")
+      nil
+  """
+
+  def find(contents, page_id, name) do
+    contents
+    |> Enum.find(fn c -> c.name == name && c.page_id == page_id end)
+  end
+
 end

--- a/lib/thesis/store.ex
+++ b/lib/thesis/store.ex
@@ -3,14 +3,8 @@ defmodule Thesis.Store do
   Thesis.Store is an Elixir "behaviour" that defines the public function
   interface necessary for Thesis to use a particular store module.
 
-  There are currently five required functions, as described below.
+  There are currently three required functions, as described below.
   """
-
-  @doc """
-  Returns all pages currently in the database, as a list of Thesis.Page
-  structs. Will return an empty list if none are found.
-  """
-  @callback pages() :: %{String.t => Thesis.Page.t}
 
   @doc """
   Returns a Thesis.Page struct with the given slug (aka request_path).
@@ -18,11 +12,11 @@ defmodule Thesis.Store do
   @callback page(String.t) :: Thesis.Page.t
 
   @doc """
-  Returns a map consisting of string keys and Thesis.PageContent structs
-  for the given Thesis.Page struct. This is generally used to populate the
-  page content using the Thesis.View.content/4 function.
+  Returns a list of related Thesis.PageContent structs both for the given
+  Thesis.Page struct and global content areas. This is generally used to
+  populate the page content using the Thesis.View.content/4 function.
   """
-  @callback page_contents(Thesis.Page.t) :: %{String.t => Thesis.PageContent.t}
+  @callback page_contents(Thesis.Page.t) :: [ Thesis.PageContent.t ]
 
   @doc """
   Updates the given page (identified by its slug) with the given map of

--- a/lib/thesis/stores/ecto_store.ex
+++ b/lib/thesis/stores/ecto_store.ex
@@ -14,25 +14,17 @@ defmodule Thesis.EctoStore do
   import Thesis.Config
   alias Thesis.{ Page, PageContent }
 
-  def pages do
-    repo.all(Page)
-      |> Map.new(&slug_page_tuple/1)
-  end
-
   def page(slug) when is_binary(slug) do
     repo.get_by(Page, slug: slug)
   end
 
-  def page_contents(%Page{id: page_id}) do
-    repo.all(PageContent, page_id: [nil, page_id])
-  end
-
+  def page_contents(nil), do: []
   def page_contents(slug) when is_binary(slug) do
     page_contents(page(slug))
   end
 
-  def page_contents(nil) do
-    %{}
+  def page_contents(%Page{id: page_id}) do
+    repo.all(PageContent, page_id: [nil, page_id])
   end
 
   def update(%{"slug" => slug} = page_params, contents_params) do
@@ -60,10 +52,6 @@ defmodule Thesis.EctoStore do
     updated_properties = %{content: content, content_type: content_type}
 
     Ecto.Changeset.cast(page_content, updated_properties, ~w(content content_type), [])
-  end
-
-  defp slug_page_tuple(%Page{slug: slug} = page) do
-    {slug, page}
   end
 
   defp page_id_or_global(%{"global" => "true"}, _page), do: nil

--- a/priv/static/thesis-editor.js
+++ b/priv/static/thesis-editor.js
@@ -27269,7 +27269,7 @@ var AttributionText = function (_React$Component) {
           { href: "//github.com/infinitered/thesis-phoenix", target: "_blank" },
           "Thesis"
         ),
-        " is maintained by ",
+        "is maintained by ",
         _react2.default.createElement(
           "a",
           { href: "//infinite.red", target: "_blank" },
@@ -27988,8 +27988,9 @@ var ThesisEditor = function (_React$Component) {
         var ed = editors[i];
         var id = ed.getAttribute('data-thesis-content-id');
         var t = ed.getAttribute('data-thesis-content-type');
+        var glob = ed.getAttribute('data-thesis-content-global');
         var content = ed.innerHTML;
-        contents.push({ name: id, content_type: t, content: content });
+        contents.push({ name: id, content_type: t, content: content, global: glob });
       }
 
       return contents;

--- a/test/thesis_page_content_test.exs
+++ b/test/thesis_page_content_test.exs
@@ -1,0 +1,4 @@
+defmodule ThesisPageContentTest do
+  use ExUnit.Case
+  doctest Thesis.PageContent
+end

--- a/web/static/js/thesis-editor.js
+++ b/web/static/js/thesis-editor.js
@@ -194,8 +194,9 @@ class ThesisEditor extends React.Component {
       const ed = editors[i]
       const id = ed.getAttribute('data-thesis-content-id')
       const t = ed.getAttribute('data-thesis-content-type')
+      const glob = ed.getAttribute('data-thesis-content-global')
       const content = ed.innerHTML
-      contents.push({name: id, content_type: t, content: content})
+      contents.push({name: id, content_type: t, content: content, global: glob})
     }
 
     return contents


### PR DESCRIPTION
### Global Content Areas

Content areas in Thesis are page-specific. However, if you want an editable
region that can be displayed on multiple pages, use the
`Thesis.View.global_content/4` function. Internally, the page_id will be set
to `nil` to indicate it applies globally, rather than to a specific page.

```eex
<%= global_content(@conn, "Footer Text", :html) do %>
  <h4>Contact Info</h4>
  <ul>
    <li>Call us at (800) 555-1212</li>
    <li>Email us at hello@example.com.</li>
  </ul>
<% end %>
```

Special thanks to @yulianglukhenko for pairing with me on this feature. Fixes #15 .
