### PR TITLE
Fix compilation warnings on generated files

### DIFF
--- a/apps/example/priv/repo/migrations/20161123212846_create_thesis_files_table.exs
+++ b/apps/example/priv/repo/migrations/20161123212846_create_thesis_files_table.exs
@@ -9,7 +9,7 @@ defmodule Example.Repo.Migrations.CreateThesisFilesTable do
       add :filename, :string
       add :data, :binary
 
-      timestamps
+      timestamps()
     end
     create unique_index(:thesis_files, [:slug])
   end

--- a/apps/example/priv/repo/migrations/20170422064010_create_thesis_backups_table.exs
+++ b/apps/example/priv/repo/migrations/20170422064010_create_thesis_backups_table.exs
@@ -8,7 +8,7 @@ defmodule Example.Repo.Migrations.CreateThesisBackupsTable do
       add :page_revision, :integer
       add :page_data, :binary
 
-      timestamps
+      timestamps()
     end
   end
 end

--- a/priv/templates/thesis.install/create_thesis_files_table.exs
+++ b/priv/templates/thesis.install/create_thesis_files_table.exs
@@ -9,7 +9,7 @@ defmodule <%= base %>.Repo.Migrations.CreateThesisFilesTable do
       add :filename, :string
       add :data, :binary
 
-      timestamps
+      timestamps()
     end
     create unique_index(:thesis_files, [:slug])
   end

--- a/priv/templates/thesis.install/create_thesis_tables.exs
+++ b/priv/templates/thesis.install/create_thesis_tables.exs
@@ -8,7 +8,7 @@ defmodule <%= base %>.Repo.Migrations.CreateThesisTables do
       add :title, :string
       add :description, :string
 
-      timestamps
+      timestamps()
     end
 
     create table(:thesis_page_contents) do

--- a/priv/templates/thesis.install/thesis_auth.exs
+++ b/priv/templates/thesis.install/thesis_auth.exs
@@ -5,7 +5,7 @@ defmodule <%= base %>.ThesisAuth do
 
   @behaviour Thesis.Auth
 
-  def page_is_editable?(conn) do
+  def page_is_editable?(_conn) do
     # Editable by the world
     true
 


### PR DESCRIPTION
These three files in priv/templates/thesis.install contain compilation warnings that the user has to fix after running `mix thesis.install`. This fixes that issue as well as the compilation warnings in the example app's migrations.