### PR TITLE
Removed Unnecessary Width Value

### DIFF
--- a/assets/css/components/_editor.sass
+++ b/assets/css/components/_editor.sass
@@ -16,7 +16,6 @@ body.thesis-tray-open
   font-size       : 0
   text-decoration : none
   height          : 315px
-  width           : 85px
 
   &:not(.active):hover
     .thesis-button.add, .thesis-button.delete


### PR DESCRIPTION
The width value is is causing the hidden editor to block user access to the document under it. Removing the width did not change the functionality

See Below for example

![no-wdith](https://user-images.githubusercontent.com/100886/30505885-1aee1896-9a3d-11e7-893a-cc1c7a8fd51c.gif)
