### PR TITLE
Fix README formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,10 @@
 
   <tr><td><h4>Changelog</h4></td></tr>
   <tr>
-    <td><strong>0.3.1</strong></td>
-    - Fixes issue #155 [pr #156](https://github.com/infinitered/thesis-phoenix/pull/156)
-    Ambiguous call to function repo/0 on `mix ecto.migrate` - Phoenix 1.4
-  </tr>
-  <tr>
     <td>
+      <strong>0.3.1</strong><br/>
+      - Fixes issue #155 [pr #156](https://github.com/infinitered/thesis-phoenix/pull/156) Ambiguous call to function repo/0 on `mix ecto.migrate` - Phoenix 1.4
+      <br/><br/>
       <strong>0.3.0</strong><br/>
       - Removes the LZString compression for backups (page revisions) as per the conversation <a href="https://github.com/infinitered/thesis-phoenix/issues/129">here</a>. <br/>
       - <em>Adds migration (run `mix thesis.install && mix ecto.migrate`)</em>. It is important to do this before 0.4.0 as the LZString dependency will be removed then.<br/>


### PR DESCRIPTION
Changelog table cell was incorrectly showing at top of README. This fixes the HTML table markup to be consistent with the rest of the Changelog section.

**Before:** top of the current README looks like this:

![image](https://user-images.githubusercontent.com/809823/54715073-6e32d900-4b4a-11e9-80ae-5102dec99b37.png)

**After** this change fixes that:

![image](https://user-images.githubusercontent.com/809823/54715110-8a367a80-4b4a-11e9-8dc8-945983f92ee9.png)

