### PR TITLE
Fix warning: "not expr1 in expr2" is deprecated.

### DIFF
--- a/lib/thesis/api_controller.ex
+++ b/lib/thesis/api_controller.ex
@@ -5,7 +5,7 @@ defmodule Thesis.ApiController do
   import Thesis.Config
   alias Thesis.{Utilities, Backup}
 
-  plug :ensure_authorized! when not action in [:show_file]
+  plug :ensure_authorized! when not(action in [:show_file])
 
   def assets(conn, _params), do: conn
 


### PR DESCRIPTION
warning: "not expr1 in expr2" is deprecated. Instead use "expr1 not in expr2" if you require Elixir v1.5+, or "not(expr1 in expr2)" if you have to support earlier Elixir versions